### PR TITLE
Setting number of genie universes for numi

### DIFF
--- a/Selection/job/numi/run_neutrinoselectionfilter_run1_overlay_numi.fcl
+++ b/Selection/job/numi/run_neutrinoselectionfilter_run1_overlay_numi.fcl
@@ -12,6 +12,7 @@ EventWeightTreeTool: {
     createSplineTimesTuneBranch: true
     createPPFXBranch: true
     makeNuMINtuple: true
+    GenieAllUniverses: 600
 }
 
 #For Nicolo


### PR DESCRIPTION
Sets number of genie universes for numi to 600, from default 500