### PR TITLE
Truth variables bug fix + BNB wiremod fcl scripts

### DIFF
--- a/Selection/AnalysisTools/DefaultAnalysis_tool.cc
+++ b/Selection/AnalysisTools/DefaultAnalysis_tool.cc
@@ -1207,6 +1207,7 @@ void DefaultAnalysis::resetTTree(TTree *_tree)
 {
   _leeweight = 0;
   _nu_e = std::numeric_limits<float>::lowest();
+  _lep_e = std::numeric_limits<float>::lowest();
   _nu_l = std::numeric_limits<float>::lowest();
   _theta = std::numeric_limits<float>::lowest();
   _nu_pt = std::numeric_limits<float>::lowest();
@@ -1241,6 +1242,7 @@ void DefaultAnalysis::resetTTree(TTree *_tree)
 
   _interaction = std::numeric_limits<int>::lowest();
   _pass = 0;
+  _swtrig = 0;
 
   _opfilter_pe_beam = 0.;
   _opfilter_pe_veto = 0.;
@@ -1262,6 +1264,7 @@ void DefaultAnalysis::resetTTree(TTree *_tree)
   _reco_nu_vtx_sce_z = std::numeric_limits<float>::lowest();
 
   _isVtxInFiducial = false;
+  _truthFiducial = false;
 
   _nslice = 0;
   _crtveto = 0;

--- a/Selection/AnalysisTools/MCS_tool.cc
+++ b/Selection/AnalysisTools/MCS_tool.cc
@@ -851,8 +851,8 @@ void MCS::resetTTree(TTree *_tree)
 
   _shrPCALen = -1; _n_shrSpcPts = -1;
 
-  _DeltaMed = -1; _DeltaMed1h = -1; _DeltaMed2h = -1;
-  _DeltaMed = -1; _DeltaRMS1h = -1; _DeltaRMS2h = -1;
+  _DeltaMed = -1; _DeltaRMS = -1; _DeltaMed1h = -1; _DeltaMed2h = -1;
+  _DeltaMed = -1; _DeltaRMS = -1; _DeltaRMS1h = -1; _DeltaRMS2h = -1;
 
   _CylFrac_1cm = -1; _CylFrac1h_1cm = -1; _CylFrac2h_1cm = -1;
   _CylFrac_2cm = -1; _CylFrac1h_2cm = -1; _CylFrac2h_2cm = -1;

--- a/Selection/AnalysisTools/Pi0Tagger_tool.cc
+++ b/Selection/AnalysisTools/Pi0Tagger_tool.cc
@@ -775,6 +775,13 @@ void Pi0Tagger::analyzeEvent(art::Event const &e, bool fData)
     _pi0_dir2_y = 0;
     _pi0_dir2_z = 0;
 
+    _pi0_dedx1_fit_Y = 0;
+    _pi0_dedx2_fit_Y = 0;
+    _pi0_dedx1_fit_V = 0;
+    _pi0_dedx2_fit_V = 0;
+    _pi0_dedx1_fit_U = 0;
+    _pi0_dedx2_fit_U = 0;
+
     _pi0_dot1 = -1;
     _pi0_dot2 = -1;
     _pi0_radlen1 = -1;

--- a/Selection/AnalysisTools/Pi0TruthAnalysis_tool.cc
+++ b/Selection/AnalysisTools/Pi0TruthAnalysis_tool.cc
@@ -405,6 +405,12 @@ void Pi0TruthAnalysis::resetTTree(TTree *_tree)
   _pi0truth_gamma1_xpos = 0;
   _pi0truth_gamma1_ypos = 0;
   _pi0truth_gamma1_zpos = 0;
+  _pi0truth_gamma1_dist = 0;
+  _pi0truth_gamma2_dist = 0;
+  _pi0truth_gammadot = 0;
+  _pi0truth_run = 0;
+  _pi0truth_sub = 0;
+  _pi0truth_evt = 0;
 
   _pi0truth_gamma2_tid = 0;
   _pi0truth_gamma2_elec1 = 0;

--- a/Selection/AnalysisTools/SlicePurCompl_tool.cc
+++ b/Selection/AnalysisTools/SlicePurCompl_tool.cc
@@ -417,6 +417,8 @@ void SlicePurCompl::setBranches(TTree *_tree)
 void SlicePurCompl::resetTTree(TTree *_tree)
 {
   origevnunhits = std::numeric_limits<int>::min();
+  nu_purity_from_pfp = std::numeric_limits<int>::min();
+  nu_completeness_from_pfp = std::numeric_limits<int>::min();
   //
   evnunhits = std::numeric_limits<int>::min();
   evlepnhits = std::numeric_limits<int>::min();

--- a/Selection/job/run_neutrinoselectionfilter_run1_overlay_cc0pinp_for_wiremod.fcl
+++ b/Selection/job/run_neutrinoselectionfilter_run1_overlay_cc0pinp_for_wiremod.fcl
@@ -1,0 +1,7 @@
+################################################
+# Version for WIREMOD detector variation files #
+################################################
+#include "run_neutrinoselectionfilter_run1_overlay_cc0pinp.fcl"
+
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHTproducer: "gaushitTruthMatch::OverlayWireModRecoStage1b"
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHproducer: "gaushit::OverlayWireModRecoStage1a"

--- a/Selection/job/run_neutrinoselectionfilter_run3_overlay_cc0pinp_for_wiremod.fcl
+++ b/Selection/job/run_neutrinoselectionfilter_run3_overlay_cc0pinp_for_wiremod.fcl
@@ -1,0 +1,7 @@
+################################################
+# Version for WIREMOD detector variation files #
+################################################
+#include "run_neutrinoselectionfilter_run3_overlay_cc0pinp.fcl"
+
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHTproducer: "gaushitTruthMatch::OverlayWireModRecoStage1b"
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHproducer: "gaushit::OverlayWireModRecoStage1a"

--- a/Selection/job/run_neutrinoselectionfilter_run4_overlay_cc0pinp_for_wiremod.fcl
+++ b/Selection/job/run_neutrinoselectionfilter_run4_overlay_cc0pinp_for_wiremod.fcl
@@ -1,0 +1,7 @@
+################################################
+# Version for WIREMOD detector variation files #
+################################################
+#include "run_neutrinoselectionfilter_run4_overlay_cc0pinp.fcl"
+
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHTproducer: "gaushitTruthMatch::OverlayWireModRecoStage1b"
+physics.filters.nuselection.AnalysisTools.slicepurcompl.OrigHproducer: "gaushit::OverlayWireModRecoStage1a"


### PR DESCRIPTION
This pr does two things:
- Fixes a minor issue with some truth variables being declared but not initialised when running on data (leads to randomly fluctuating values)
- Adds three fcl files that fix an issue with the current scripts not working on wiremod detector variations for BNB.