### PR TITLE
Bug fix and variable name changing

### DIFF
--- a/Selection/AnalysisTools/FlashMatching_tool.cc
+++ b/Selection/AnalysisTools/FlashMatching_tool.cc
@@ -88,11 +88,11 @@ namespace analysis
     art::InputTag fHproducer;
     art::InputTag fHTproducer;
 
-    float _flash_pe;
-    float _flash_time, _flash_timewidth;
-    float _flash_y, _flash_z, _flash_ywidth, _flash_zwidth;
-    std::vector<float> _flash_pe_v; //* reconstructed PE spectrum across PMT array *//
-    std::vector<float> _slice_pe_v; //* hypothesized PE spectrum based on TPC charge across PMT array *//
+    float _flash_pe_flash_matching;
+    float _flash_time_flash_matching, _flash_timewidth_flash_matching;
+    float _flash_y_flash_matching, _flash_z_flash_matching, _flash_ywidth_flash_matching, _flash_zwidth_flash_matching;
+    std::vector<float> _flash_pe_flash_matching_v; //* reconstructed PE spectrum across PMT array *//
+    std::vector<float> _slice_pe_flash_matching_v; //* hypothesized PE spectrum based on TPC charge across PMT array *//
 
     float _nu_flashmatch_score;
     float _nu_centerX, _nu_centerY, _nu_centerZ, _nu_totalCharge;
@@ -230,15 +230,16 @@ namespace analysis
 
       auto flash = flash_h->at(f);
 
-      if (flash.TotalPE() > _flash_pe) {
-	_flash_pe    = flash.TotalPE();
-	_flash_time  = flash.Time();
-	_flash_y = flash.YCenter();
-	_flash_z = flash.ZCenter();
-	_flash_timewidth = flash.TimeWidth();
-	_flash_ywidth = flash.YWidth();
-	_flash_zwidth = flash.ZWidth();
-	ibeamFlash = f;
+      if (flash.TotalPE() > _flash_pe_flash_matching) {
+        _flash_pe_flash_matching    = flash.TotalPE();
+        _flash_time_flash_matching  = flash.Time();
+        _flash_y_flash_matching = flash.YCenter();
+        _flash_z_flash_matching = flash.ZCenter();
+        _flash_timewidth_flash_matching = flash.TimeWidth();
+        _flash_ywidth_flash_matching = flash.YWidth();
+        _flash_zwidth_flash_matching = flash.ZWidth();
+        ibeamFlash = f;
+
       }// if larger then other flashes
 
     }// for all flashes
@@ -317,11 +318,12 @@ namespace analysis
       flashmatch::SliceCandidate slice(pfp_ptr_v, spacepoint_v_v, hit_v_v, m_chargeToNPhotonsTrack, m_chargeToNPhotonsShower, m_applyLifetimeCorr);
       float fmscore = 1e6;
       if (ibeamFlash != flash_h->size()) {
-	flashmatch::FlashCandidate beamFlash(e,flash_h->at(ibeamFlash));
-	fmscore = slice.GetFlashMatchScore(beamFlash, m_flashMatchManager);
-	// store flash PE spectrum in the ordering as used by Flash-Matching 
-	_flash_pe_v = beamFlash.m_peSpectrum;
-	_slice_pe_v = beamFlash.m_peHypSpectrum;
+        flashmatch::FlashCandidate beamFlash(e,flash_h->at(ibeamFlash));
+        fmscore = slice.GetFlashMatchScore(beamFlash, m_flashMatchManager);
+        // store flash PE spectrum in the ordering as used by Flash-Matching 
+
+        _flash_pe_flash_matching_v = beamFlash.m_peSpectrum;
+        _slice_pe_flash_matching_v = beamFlash.m_peHypSpectrum;
       }
       // get flash-match score (in case there is a valid T0 for all outcomes...)
       // size_t key = pfp_ptr.key();
@@ -373,15 +375,15 @@ namespace analysis
   void FlashMatching::setBranches(TTree* _tree)
   {
 
-    _tree->Branch("flash_pe",&_flash_pe,"flash_pe/F");
-    _tree->Branch("flash_pe_v","std::vector<float>",&_flash_pe_v);
-    _tree->Branch("slice_pe_v","std::vector<float>",&_slice_pe_v);
-    _tree->Branch("flash_time",&_flash_time,"flash_time/F");
-    _tree->Branch("flash_y",&_flash_y,"flash_y/F");
-    _tree->Branch("flash_z",&_flash_z,"flash_z/F");
-    _tree->Branch("flash_timewidth",&_flash_timewidth,"flash_timewidth/F");
-    _tree->Branch("flash_ywidth",&_flash_ywidth,"flash_ywidth/F");
-    _tree->Branch("flash_zwidth",&_flash_zwidth,"flash_zwidth/F");
+    _tree->Branch("flash_pe_flash_matching",&_flash_pe_flash_matching,"flash_pe_flash_matching/F");
+    _tree->Branch("flash_pe_flash_matching_v","std::vector<float>",&_flash_pe_flash_matching_v);
+    _tree->Branch("slice_pe_flash_matching_v","std::vector<float>",&_slice_pe_flash_matching_v);
+    _tree->Branch("flash_time_flash_matching",&_flash_time_flash_matching,"flash_time_flash_matching/F");
+    _tree->Branch("flash_y_flash_matching",&_flash_y_flash_matching,"flash_y_flash_matching/F");
+    _tree->Branch("flash_z_flash_matching",&_flash_z_flash_matching,"flash_z_flash_matching/F");
+    _tree->Branch("flash_timewidth_flash_matching",&_flash_timewidth_flash_matching,"flash_timewidth_flash_matching/F");
+    _tree->Branch("flash_ywidth_flash_matching",&_flash_ywidth_flash_matching,"flash_ywidth_flash_matching/F");
+    _tree->Branch("flash_zwidth_flash_matching",&_flash_zwidth_flash_matching,"flash_zwidth_flash_matching/F");
 
     _tree->Branch("nu_flashmatch_score",&_nu_flashmatch_score,"nu_flashmatch_score/F");
     _tree->Branch("nu_centerX",&_nu_centerX,"nu_centerX/F");
@@ -419,13 +421,13 @@ namespace analysis
     _cosmic_nhits_v.clear();
     _cosmic_nunhits_v.clear();
     _cosmic_isclear_v.clear();
-    _flash_pe   = std::numeric_limits<float>::lowest();
-    _flash_time = std::numeric_limits<float>::lowest();
-    _flash_y = std::numeric_limits<float>::lowest();
-    _flash_z = std::numeric_limits<float>::lowest();
-    _flash_timewidth = std::numeric_limits<float>::lowest();
-    _flash_ywidth = std::numeric_limits<float>::lowest();
-    _flash_zwidth = std::numeric_limits<float>::lowest();
+    _flash_pe_flash_matching   = std::numeric_limits<float>::lowest();
+    _flash_time_flash_matching = std::numeric_limits<float>::lowest();
+    _flash_y_flash_matching = std::numeric_limits<float>::lowest();
+    _flash_z_flash_matching = std::numeric_limits<float>::lowest();
+    _flash_timewidth_flash_matching = std::numeric_limits<float>::lowest();
+    _flash_ywidth_flash_matching = std::numeric_limits<float>::lowest();
+    _flash_zwidth_flash_matching = std::numeric_limits<float>::lowest();
   }
 
   void FlashMatching::AddDaughters(const art::Ptr<recob::PFParticle>& pfp_ptr,  const art::ValidHandle<std::vector<recob::PFParticle> >& pfp_h, std::vector<art::Ptr<recob::PFParticle> > &pfp_v) {

--- a/Selection/AnalysisTools/PMTWaveform_tool.cc
+++ b/Selection/AnalysisTools/PMTWaveform_tool.cc
@@ -95,10 +95,10 @@ namespace analysis
     art::InputTag fFLASHCALIBproducer;
     art::InputTag fPMTWFproducer;
 
-    float _flash_pe_uncalib, _flash_pe_uncalib_calib;
+    float _flash_pe, _flash_pe_calib;
     float _flash_zcenter, _flash_ycenter, _flash_zwidth, _flash_ywidth;
-    std::vector<float> _flash_pe_uncalib_v;
-    std::vector<float> _flash_pe_uncalib_calib_v;
+    std::vector<float> _flash_pe_v;
+    std::vector<float> _flash_pe_calib_v;
     std::vector<float> _gain_ampl_v, _gain_area_v;
     float _flash_time;
     std::vector< std::vector<short> > _opwf_v;
@@ -181,8 +181,8 @@ namespace analysis
 
       auto flash = flash_h->at(f);
       
-      if (flash.TotalPE() > _flash_pe_uncalib) {
-        _flash_pe_uncalib    = flash.TotalPE();
+      if (flash.TotalPE() > _flash_pe) {
+        _flash_pe    = flash.TotalPE();
         _flash_time  = flash.Time();
         _flash_zcenter = flash.ZCenter();
         _flash_zwidth  = flash.ZWidth();
@@ -190,7 +190,7 @@ namespace analysis
         _flash_ywidth  = flash.YWidth();
 
         for (int pmt=0; pmt < 32; pmt++){
-          _flash_pe_uncalib_v[pmt] = flash.PE(pmt);
+          _flash_pe_v[pmt] = flash.PE(pmt);
         }
       }// if larger then other flashes
 
@@ -204,10 +204,10 @@ namespace analysis
 
       auto flash = flash_calib_h->at(f);
 
-      if (flash.TotalPE() > _flash_pe_uncalib_calib) {
-	      _flash_pe_uncalib_calib = flash.TotalPE();
+      if (flash.TotalPE() > _flash_pe_calib) {
+	      _flash_pe_calib = flash.TotalPE();
         for (int pmt=0; pmt < 32; pmt++){
-          _flash_pe_uncalib_calib_v[pmt] = flash.PE(pmt);
+          _flash_pe_calib_v[pmt] = flash.PE(pmt);
         }
       }// if larger then other flashes                                                                                                                                       
     }// for all calibrated flashes
@@ -245,18 +245,18 @@ namespace analysis
     std::cout << "[PMTWaveformTool] setBranches begin" << std::endl;
 
     _opwf_v = std::vector< std::vector<short> >(32,std::vector<short>(700,0));
-    _flash_pe_uncalib_v = std::vector<float>(32,0);
-    _flash_pe_uncalib_calib_v = std::vector<float>(32,0);
+    _flash_pe_v = std::vector<float>(32,0);
+    _flash_pe_calib_v = std::vector<float>(32,0);
 
-    _tree->Branch("flash_pe_uncalib",&_flash_pe_uncalib,"flash_pe_uncalib/F");
-    _tree->Branch("flash_pe_uncalib_calib",&_flash_pe_uncalib_calib,"flash_pe_uncalib_calib/F");
+    _tree->Branch("flash_pe_uncalib",&_flash_pe,"flash_pe_uncalib/F");
+    _tree->Branch("flash_pe_uncalib_calib",&_flash_pe_calib,"flash_pe_uncalib_calib/F");
     _tree->Branch("flash_time",&_flash_time,"flash_time/F");
     _tree->Branch("flash_zcenter",&_flash_zcenter,"flash_zcenter/F"); 
     _tree->Branch("flash_ycenter",&_flash_ycenter,"flash_ycenter/F");
     _tree->Branch("flash_zwidth",&_flash_zwidth,"flash_zwidth/F");
     _tree->Branch("flash_ywidth",&_flash_ywidth,"flash_ywidth/F");
-    _tree->Branch("flash_pe_uncalib_v","std::vector<float>",&_flash_pe_uncalib_v);
-    _tree->Branch("flash_pe_uncalib_calib_v","std::vector<float>",&_flash_pe_uncalib_calib_v);
+    _tree->Branch("flash_pe_uncalib_v","std::vector<float>",&_flash_pe_v);
+    _tree->Branch("flash_pe_uncalib_calib_v","std::vector<float>",&_flash_pe_calib_v);
     _tree->Branch("gain_area_v","std::vector<float>",&_gain_area_v);
     _tree->Branch("gain_ampl_v","std::vector<float>",&_gain_ampl_v);
 
@@ -272,13 +272,13 @@ namespace analysis
 
     std::cout << "[PMTWaveformTool] resetTTree begin" << std::endl;
 
-    _flash_pe_uncalib   = std::numeric_limits<float>::lowest();
-    _flash_pe_uncalib_calib   = std::numeric_limits<float>::lowest();
+    _flash_pe   = std::numeric_limits<float>::lowest();
+    _flash_pe_calib   = std::numeric_limits<float>::lowest();
     _flash_time = std::numeric_limits<float>::lowest();
     _gain_area_v = std::vector<float>(32,0);
     _gain_ampl_v = std::vector<float>(32,0);
-    _flash_pe_uncalib_v = std::vector<float>(32,0);
-    _flash_pe_uncalib_calib_v = std::vector<float>(32,0);
+    _flash_pe_v = std::vector<float>(32,0);
+    _flash_pe_calib_v = std::vector<float>(32,0);
 
     std::cout << "[PMTWaveformTool] resetTTree end" << std::endl;
 

--- a/Selection/AnalysisTools/PMTWaveform_tool.cc
+++ b/Selection/AnalysisTools/PMTWaveform_tool.cc
@@ -95,10 +95,10 @@ namespace analysis
     art::InputTag fFLASHCALIBproducer;
     art::InputTag fPMTWFproducer;
 
-    float _flash_pe, _flash_pe_calib;
+    float _flash_pe_uncalib, _flash_pe_uncalib_calib;
     float _flash_zcenter, _flash_ycenter, _flash_zwidth, _flash_ywidth;
-    std::vector<float> _flash_pe_v;
-    std::vector<float> _flash_pe_calib_v;
+    std::vector<float> _flash_pe_uncalib_v;
+    std::vector<float> _flash_pe_uncalib_calib_v;
     std::vector<float> _gain_ampl_v, _gain_area_v;
     float _flash_time;
     std::vector< std::vector<short> > _opwf_v;
@@ -177,20 +177,21 @@ namespace analysis
     // FLASH
     art::Handle<std::vector<recob::OpFlash> > flash_h;
     e.getByLabel( fFLASHproducer , flash_h );   
-    
     for (size_t f=0; f < flash_h->size(); f++) {
 
       auto flash = flash_h->at(f);
       
-      if (flash.TotalPE() > _flash_pe) {
-	_flash_pe    = flash.TotalPE();
-	_flash_time  = flash.Time();
-	_flash_zcenter = flash.ZCenter();
-	_flash_zwidth  = flash.ZWidth();
-	_flash_ycenter = flash.YCenter();
-	_flash_ywidth  = flash.YWidth();
-	for (int pmt=0; pmt < 32; pmt++)
-	  _flash_pe_v[pmt] = flash.PE(pmt);
+      if (flash.TotalPE() > _flash_pe_uncalib) {
+        _flash_pe_uncalib    = flash.TotalPE();
+        _flash_time  = flash.Time();
+        _flash_zcenter = flash.ZCenter();
+        _flash_zwidth  = flash.ZWidth();
+        _flash_ycenter = flash.YCenter();
+        _flash_ywidth  = flash.YWidth();
+
+        for (int pmt=0; pmt < 32; pmt++){
+          _flash_pe_uncalib_v[pmt] = flash.PE(pmt);
+        }
       }// if larger then other flashes
 
     }// for all flashes
@@ -198,15 +199,16 @@ namespace analysis
     // FLASH (CALIBRATED)
     art::Handle<std::vector<recob::OpFlash> > flash_calib_h;
     e.getByLabel( fFLASHCALIBproducer , flash_calib_h );
-
+  
     for (size_t f=0; f < flash_calib_h->size(); f++) {
 
       auto flash = flash_calib_h->at(f);
 
-      if (flash.TotalPE() > _flash_pe) {
-	_flash_pe_calib = flash.TotalPE();
-        for (int pmt=0; pmt < 32; pmt++)
-          _flash_pe_calib_v[pmt] = flash.PE(pmt);
+      if (flash.TotalPE() > _flash_pe_uncalib_calib) {
+	      _flash_pe_uncalib_calib = flash.TotalPE();
+        for (int pmt=0; pmt < 32; pmt++){
+          _flash_pe_uncalib_calib_v[pmt] = flash.PE(pmt);
+        }
       }// if larger then other flashes                                                                                                                                       
     }// for all calibrated flashes
     
@@ -243,18 +245,18 @@ namespace analysis
     std::cout << "[PMTWaveformTool] setBranches begin" << std::endl;
 
     _opwf_v = std::vector< std::vector<short> >(32,std::vector<short>(700,0));
-    _flash_pe_v = std::vector<float>(32,0);
-    _flash_pe_calib_v = std::vector<float>(32,0);
+    _flash_pe_uncalib_v = std::vector<float>(32,0);
+    _flash_pe_uncalib_calib_v = std::vector<float>(32,0);
 
-    _tree->Branch("flash_pe",&_flash_pe,"flash_pe/F");
-    _tree->Branch("flash_pe_calib",&_flash_pe_calib,"flash_pe_calib/F");
+    _tree->Branch("flash_pe_uncalib",&_flash_pe_uncalib,"flash_pe_uncalib/F");
+    _tree->Branch("flash_pe_uncalib_calib",&_flash_pe_uncalib_calib,"flash_pe_uncalib_calib/F");
     _tree->Branch("flash_time",&_flash_time,"flash_time/F");
     _tree->Branch("flash_zcenter",&_flash_zcenter,"flash_zcenter/F"); 
     _tree->Branch("flash_ycenter",&_flash_ycenter,"flash_ycenter/F");
     _tree->Branch("flash_zwidth",&_flash_zwidth,"flash_zwidth/F");
     _tree->Branch("flash_ywidth",&_flash_ywidth,"flash_ywidth/F");
-    _tree->Branch("flash_pe_v","std::vector<float>",&_flash_pe_v);
-    _tree->Branch("flash_pe_calib_v","std::vector<float>",&_flash_pe_calib_v);
+    _tree->Branch("flash_pe_uncalib_v","std::vector<float>",&_flash_pe_uncalib_v);
+    _tree->Branch("flash_pe_uncalib_calib_v","std::vector<float>",&_flash_pe_uncalib_calib_v);
     _tree->Branch("gain_area_v","std::vector<float>",&_gain_area_v);
     _tree->Branch("gain_ampl_v","std::vector<float>",&_gain_ampl_v);
 
@@ -270,13 +272,13 @@ namespace analysis
 
     std::cout << "[PMTWaveformTool] resetTTree begin" << std::endl;
 
-    _flash_pe   = std::numeric_limits<float>::lowest();
-    _flash_pe_calib   = std::numeric_limits<float>::lowest();
+    _flash_pe_uncalib   = std::numeric_limits<float>::lowest();
+    _flash_pe_uncalib_calib   = std::numeric_limits<float>::lowest();
     _flash_time = std::numeric_limits<float>::lowest();
     _gain_area_v = std::vector<float>(32,0);
     _gain_ampl_v = std::vector<float>(32,0);
-    _flash_pe_v = std::vector<float>(32,0);
-    _flash_pe_calib_v = std::vector<float>(32,0);
+    _flash_pe_uncalib_v = std::vector<float>(32,0);
+    _flash_pe_uncalib_calib_v = std::vector<float>(32,0);
 
     std::cout << "[PMTWaveformTool] resetTTree end" << std::endl;
 

--- a/Selection/AnalysisTools/PMTWaveform_tool.cc
+++ b/Selection/AnalysisTools/PMTWaveform_tool.cc
@@ -248,15 +248,15 @@ namespace analysis
     _flash_pe_v = std::vector<float>(32,0);
     _flash_pe_calib_v = std::vector<float>(32,0);
 
-    _tree->Branch("flash_pe_uncalib",&_flash_pe,"flash_pe_uncalib/F");
-    _tree->Branch("flash_pe_uncalib_calib",&_flash_pe_calib,"flash_pe_uncalib_calib/F");
+    _tree->Branch("flash_pe",&_flash_pe,"flash_pe/F");
+    _tree->Branch("flash_pe_calib",&_flash_pe_calib,"flash_pe_calib/F");
     _tree->Branch("flash_time",&_flash_time,"flash_time/F");
     _tree->Branch("flash_zcenter",&_flash_zcenter,"flash_zcenter/F"); 
     _tree->Branch("flash_ycenter",&_flash_ycenter,"flash_ycenter/F");
     _tree->Branch("flash_zwidth",&_flash_zwidth,"flash_zwidth/F");
     _tree->Branch("flash_ywidth",&_flash_ywidth,"flash_ywidth/F");
-    _tree->Branch("flash_pe_uncalib_v","std::vector<float>",&_flash_pe_v);
-    _tree->Branch("flash_pe_uncalib_calib_v","std::vector<float>",&_flash_pe_calib_v);
+    _tree->Branch("flash_pe_v","std::vector<float>",&_flash_pe_v);
+    _tree->Branch("flash_pe_calib_v","std::vector<float>",&_flash_pe_calib_v);
     _tree->Branch("gain_area_v","std::vector<float>",&_gain_area_v);
     _tree->Branch("gain_ampl_v","std::vector<float>",&_gain_ampl_v);
 


### PR DESCRIPTION
Hi, in this PR, I have modified two files: 
- In [Selection/AnalysisTools/FlashMatching_tool.cc](https://github.com/ubneutrinos/searchingfornues/compare/v30genie...Li-Jiaoyang97:searchingfornues:jiaoyang_isolated_proton2?expand=1#diff-0aa52a4477e5cb301175b72f1ef7a703b8e735120bdd65a71c73b1429f03a090): I added __flash_match_ to the flash-related variable names since these name can also be found in [Selection/AnalysisTools/PMTWaveform_tool.cc](https://github.com/ubneutrinos/searchingfornues/compare/v30genie...Li-Jiaoyang97:searchingfornues:jiaoyang_isolated_proton2?expand=1#diff-a4f80822a03b8189ee7906f92c13f5b49d2627af6a3a5aabca600f223669c662); Please let me know if you want to do it differently. 
- In [Selection/AnalysisTools/PMTWaveform_tool.cc](https://github.com/ubneutrinos/searchingfornues/compare/v30genie...Li-Jiaoyang97:searchingfornues:jiaoyang_isolated_proton2?expand=1#diff-a4f80822a03b8189ee7906f92c13f5b49d2627af6a3a5aabca600f223669c662), I fixed the if-condition, see the line 207, which preventing the calibrated PE being filled. 